### PR TITLE
Fix set /p error handling

### DIFF
--- a/src/FlashpointURLs.bat
+++ b/src/FlashpointURLs.bat
@@ -5,5 +5,6 @@ SET "FPARG=%~1"
 SET "FPARG=%FPARG:/=%"
 SET "FPARG=%FPARG:flashpoint:=%"
 SET "FPARG=%FPARG:~0,36%"
-echo(!!FPARG!!|findstr /r /x "[0-9a-f-]*"|set /p "FPARG=")
+echo(!!FPARG!!|findstr /r /i /x "[0-9a-f-]*"|set /p "FPARG="
+If !ERRORLEVEL! NEQ 0 echo Error, "GUID is invalid" & exit /b
 start "" "CLIFp.exe" --quiet --auto !FPARG!


### PR DESCRIPTION
Stop set /p from re-assigning FPARG's original value when findstr fails + error message